### PR TITLE
FullScreen by Default and Text Speed Change

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -119,13 +119,18 @@ define config.window_hide_transition = Dissolve(.2)
 ## Controls the default text speed. The default, 0, is infinite, while any other
 ## number is the number of characters per second to type out.
 
-default preferences.text_cps = 0
+default preferences.text_cps = 40
 
 
 ## The default auto-forward delay. Larger numbers lead to longer waits, with 0
 ## to 30 being the valid range.
 
 default preferences.afm_time = 15
+
+## Controls whether or not the project window is full screen or not. Only holds
+## the values true or false.
+
+default preferences.fullscreen = True
 
 
 ## Save directory ##############################################################


### PR DESCRIPTION
CAIN now opens to fullscreen by default and the text speed is similar to Animal Crossing (40 characters per second)